### PR TITLE
As Wpelauncher is deprecated need to point to rdkbrowser2

### DIFF
--- a/src/networks/comcast/constants.js
+++ b/src/networks/comcast/constants.js
@@ -45,7 +45,7 @@ const events = {
 };
 
 const appTypesMap = {
-    html5: 'wpe',
+    html5: 'WebApp',
     spark: 'spark',
     native: 'native',
 };


### PR DESCRIPTION
to make use of rdkbrowser2 browserapp to make use of
rdkbrowser2 --server for launching html url's in refapp

Signed-off-by: pnandyala <pavan.nandyala@lnttechservices.com>