### PR TITLE
REFPLTV-289: APPS are not working on RefApp UI

### DIFF
--- a/src/networks/comcast/constants.js
+++ b/src/networks/comcast/constants.js
@@ -45,7 +45,7 @@ const events = {
 };
 
 const appTypesMap = {
-    html5: 'wpe',
+    html5: 'WebApp',
     spark: 'spark',
     native: 'native',
 };


### PR DESCRIPTION
* make use of new WebApp application type supported by appmanager/optimus to control the rdkbrowser2 integrated into appmanager