### PR TITLE
Make sure display with fixed and known name "wayland-dac-0" is create…

### DIFF
--- a/src/networks/comcast/index.js
+++ b/src/networks/comcast/index.js
@@ -53,9 +53,12 @@ module.exports = {
     configure(app) {
         appId += 1;
         let launchParams = {};
+        let displayName;
         switch (app.appType) {
-            case 'native':
             case 'dac':
+                displayName = "wayland-dac-0";
+                // fall through
+            case 'native':
             case 'browser':
                 launchParams = { cmd: app.cmd };
                 break;
@@ -67,6 +70,7 @@ module.exports = {
         return Promise.resolve(Object.assign(DEFAULT_APP_PROPS, {
             id: appId,
             launchParams,
+            displayName: displayName
         }));
     },
 


### PR DESCRIPTION
…d for dac apps

* this fixes the focus/key handling problem. Earlier they were not
connecting to their created display but to wayland-0.

* when no displayname is passed, pxscene will create one with random
name like westeros-xxxx. See https://github.com/pxscene/pxCore/blob/51333037650ecee44191492b541106efa573cc35/examples/pxScene2d/src/pxWayland.cpp#L158