### PR TITLE
RDKCMF-8664 reference image: use RDKShell to start browser if supported

### DIFF
--- a/scripts/browser.sh
+++ b/scripts/browser.sh
@@ -2,12 +2,21 @@
 
 function stop_browser()
 {
-  curl -X PUT http://127.0.0.1/Service/Controller/Deactivate/WebKitBrowser
+  if [ -f /etc/WPEFramework/plugins/RDKShell.json ]; then
+    curl -v --header "Content-Type:application/json" --request POST http://127.0.0.1:9998/jsonrpc --data-raw "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"org.rdk.RDKShell.1.suspend\", \"params\":{ \"callsign\": \"WebKitBrowser\"} }"
+  else
+    curl -X PUT http://127.0.0.1/Service/Controller/Deactivate/WebKitBrowser
+  fi
   exit
 }
 
-curl -X PUT http://127.0.0.1/Service/Controller/Activate/WebKitBrowser
-curl -d "{\"url\":\"$1\"}" http://127.0.0.1/Service/WebKitBrowser/URL
+if [ -f /etc/WPEFramework/plugins/RDKShell.json ]; then
+  curl -v --header "Content-Type:application/json" --request POST http://127.0.0.1:9998/jsonrpc --data-raw "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"org.rdk.RDKShell.1.launch\", \"params\":{ \"callsign\": \"WebKitBrowser\", \"uri\":\"$1\" } }"
+else
+  curl -X PUT http://127.0.0.1/Service/Controller/Activate/WebKitBrowser
+  curl -d "{\"url\":\"$1\"}" http://127.0.0.1/Service/WebKitBrowser/URL
+fi
+
 trap stop_browser SIGINT SIGTERM
 while true
 do


### PR DESCRIPTION
Use RDKShell plugin (when config found) to start browser instead of WebKitBrowser plugin directly.

This is more of a demo feature of RDKShell usage. In the future RDKShell should be used directly via websockets and not via optimus.