### PR TITLE
RDKCMF-8744 Ignore moveToFront error

### DIFF
--- a/src/services/RDKServices.js
+++ b/src/services/RDKServices.js
@@ -281,12 +281,14 @@ export const startApp = async (app) => {
     result = await thunderJS['org.rdk.RDKShell'].moveToFront({ client: app.id})
   } catch (error) {
     console.log('Error on moveToFront: ', error)
-    return false
+    // ignore error
+    //return false
   }
 
-  if (result == null || !result.success) {
-    return false
-  }
+  // ignore error on moveToFront, because it will report error if client is already on top
+  //if (result == null || !result.success) {
+  //  return false
+  //}
 
   try {
     result = await thunderJS['org.rdk.RDKShell'].setFocus({ client: app.id})


### PR DESCRIPTION
* since latest RDKShell of 2021-04-16, moveToFront()
  returns error if client already on top. So ignoring
  any error from now on.
* https://github.com/rdkcentral/RDKShell/commit/76487295339f5cd86787e0d304aa10231e632e11
* saw this error in wpeframework.service log:
  [INFO] RDKShell Thread-2824 Time-63.377769: com.libertyglobal.app.waylandegltest is already in front and cannot move to front
  when enabling logging (Environment="RDKSHELL_LOG_LEVEL=DEBUG")