### PR TITLE
ONEM-33425 refapp2: use the new lisa config function

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -6,8 +6,7 @@
     },
     "rdkservicesPort": 50050,
     "sessionMgrWsRpcPort": 50050,
-    "asms-mock": true,
-    "dacFirmwareVer": "1.0.0-2b0e9ede88821f9c76f263ac7fef29739968dabd-dbg",
+    "asms-mock": false,
     "disable_qam_emu": false,
     "debug": false
   },

--- a/src/screens/AppDetailScreen/index.js
+++ b/src/screens/AppDetailScreen/index.js
@@ -36,7 +36,7 @@ import {
   startApp,
   stopApp,
   isAppRunning,
-  getPlatformNameForDAC
+  getLisaDACConfig
 } from '@/services/RDKServices'
 
 export default class AppDetailScreen extends BaseScreen {
@@ -142,8 +142,11 @@ export default class AppDetailScreen extends BaseScreen {
       this._app = applications.find((a) => { return a.id === params })
     } else {
       const url = new URL('http://' + window.location.host + '/apps/' + params)
-      const platformname = await getPlatformNameForDAC()
-      const queryParams = { platformName: platformname, firmwareVer: Settings.get('app', 'dacFirmwareVer', '') }
+      const [dacBundlePlatformNameOverride, dacBundleFirmwareCompatibilityKey] = await getLisaDACConfig()
+      const queryParams = {
+        platformName: dacBundlePlatformNameOverride,
+        firmwareVer: dacBundleFirmwareCompatibilityKey
+      }
       url.search = new URLSearchParams(queryParams).toString()
       const response = await fetch(url)
       const { header } = await response.json()


### PR DESCRIPTION
* retrieve dacBundlePlatformNameOverride and dacBundleFirmwareCompatibilityKey from LISA with getMetadata() (using special arguments)
* use these when downloading DAC apps, when asms-mock is false
* by default 'asms-mock' setting is now false instead of true