### PR TITLE
RDKCMF-8944 Update refapp2 to use ASMS config url

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -4,8 +4,8 @@
       "clearColor": "0x00000000",
       "useImageWorker": true
     },
-    "rdkservicesPort": 50050,
-    "sessionMgrWsRpcPort": 50050,
+    "rdkservicesPort": 9998,
+    "sessionMgrWsRpcPort": 8082,
     "asms-mock": false,
     "disable_qam_emu": false,
     "debug": false

--- a/src/screens/AppDetailScreen/index.js
+++ b/src/screens/AppDetailScreen/index.js
@@ -141,14 +141,18 @@ export default class AppDetailScreen extends BaseScreen {
       const { applications } = await response.json()
       this._app = applications.find((a) => { return a.id === params })
     } else {
-      const url = new URL('http://' + window.location.host + '/apps/' + params)
-      const [dacBundlePlatformNameOverride, dacBundleFirmwareCompatibilityKey] = await getLisaDACConfig()
+      const [dacBundlePlatformNameOverride, dacBundleFirmwareCompatibilityKey, asmsConfig] = await getLisaDACConfig()
+      const url = new URL(asmsConfig.url + '/apps/' + params);
       const queryParams = {
         platformName: dacBundlePlatformNameOverride,
         firmwareVer: dacBundleFirmwareCompatibilityKey
       }
       url.search = new URLSearchParams(queryParams).toString()
-      const response = await fetch(url)
+      const headers = new Headers();
+      if (asmsConfig.authentication && asmsConfig.authentication.user && asmsConfig.authentication.password) {
+        headers.append('Authorization', `Basic ${btoa(asmsConfig.authentication.user + ':' + asmsConfig.authentication.password)}`)
+      }
+      const response = await fetch(url, {headers})
       const { header } = await response.json()
       this._app = header
     }


### PR DESCRIPTION
* get configUrl from LISA config
* use it to fetch asmsURL and username and password and use it when querying ASMS
* because of this we cannot rely anymore on lighttpd routing (the asms URL is possibly dynamic)
* so we need to disable CORS security, this is done on WebkitBrowser plugin config level (we will re-use ResidentApp.json config)
* and since we do not rely on lighttpd routing anymore we can remove this also for rdkservices and sessionmgr communication (going to direct/correct TCP ports now)